### PR TITLE
Add attention head visualization notebook

### DIFF
--- a/notebooks/attention_head_visualization.ipynb
+++ b/notebooks/attention_head_visualization.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "from typing import List, Dict\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "plt.style.use('default')\n",
+    "plt.rcParams['font.size'] = 12\n",
+    "plt.rcParams['figure.figsize'] = (12, 8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from models.model_factory import create_model\n",
+    "from tasks.i2t_tasks import OperatorInductionTask\n",
+    "\n",
+    "model_name = \"OpenGVLab/InternVL3-8B-Instruct\"\n",
+    "data_dir = \"./VL-ICL\"\n",
+    "\n",
+    "print(f\"Loading model: {model_name}\")\n",
+    "model = create_model('internvl', model_name)\n",
+    "tokenizer = model.tokenizer\n",
+    "\n",
+    "# load dataset\n",
+    "task = OperatorInductionTask(data_dir)\n",
+    "print(f\"Loaded {len(task.query_data)} queries and {len(task.support_data)} support examples\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random, copy\n",
+    "n_shot = 4\n",
+    "query = task.query_data[0]\n",
+    "\n",
+    "# select demonstrations\n",
+    "support = task.select_demonstrations(query, n_shot)\n",
+    "\n",
+    "prompt_parts = [task.get_task_instruction()]\n",
+    "images = []\n",
+    "for demo in support:\n",
+    "    demo_text = task.format_demonstration(demo, include_image_token=True, mode=\"constrained\")\n",
+    "    prompt_parts.append(demo_text)\n",
+    "    if 'image' in demo:\n",
+    "        for path in demo['image']:\n",
+    "            images.append(task.load_image(path))\n",
+    "\n",
+    "query_text = task.format_query(query, include_image_token=True, mode=\"constrained\") + \" Answer: \"\n",
+    "prompt_parts.append(query_text)\n",
+    "for path in query.get('image', []):\n",
+    "    images.append(task.load_image(path))\n",
+    "\n",
+    "full_prompt = \"\n",
+    "\n",
+    "\".join(prompt_parts)\n",
+    "print(full_prompt)\n",
+    "print(f\"Total images: {len(images)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pixel_values = None\n",
+    "num_patches_list = None\n",
+    "\n",
+    "if images:\n",
+    "    if len(images) == 1:\n",
+    "        pixel_values = model.load_image(images[0], max_num=12).to(torch.bfloat16).cuda()\n",
+    "    else:\n",
+    "        pixel_values_list = []\n",
+    "        num_patches_list = []\n",
+    "        for img in images:\n",
+    "            pv = model.load_image(img, max_num=6)\n",
+    "            pixel_values_list.append(pv)\n",
+    "            num_patches_list.append(pv.size(0))\n",
+    "        pixel_values = torch.cat(pixel_values_list, dim=0).to(torch.bfloat16).cuda()\n",
+    "print(pixel_values.shape if pixel_values is not None else None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import types\n",
+    "IMG_CONTEXT_TOKEN = '<IMG_CONTEXT>'\n",
+    "img_context_token_id = tokenizer.convert_tokens_to_ids(IMG_CONTEXT_TOKEN)\n",
+    "actual_input_ids = None\n",
+    "actual_attention_mask = None\n",
+    "\n",
+    "orig_generate = model.model.generate\n",
+    "\n",
+    "def instrumented_generate(self, pixel_values=None, input_ids=None, attention_mask=None, **kwargs):\n",
+    "    global actual_input_ids, actual_attention_mask\n",
+    "    actual_input_ids = input_ids.clone()\n",
+    "    actual_attention_mask = attention_mask.clone() if attention_mask is not None else None\n",
+    "    return orig_generate(pixel_values=pixel_values, input_ids=input_ids, attention_mask=attention_mask, **kwargs)\n",
+    "\n",
+    "model.model.generate = types.MethodType(instrumented_generate, model.model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "attention_data: Dict[int, torch.Tensor] = {}\n",
+    "hooks = []\n",
+    "\n",
+    "language_model = model.model.language_model\n",
+    "num_layers = len(language_model.model.layers)\n",
+    "\n",
+    "# enable attention outputs if supported\n",
+    "if hasattr(model.model, 'config'):\n",
+    "    model.model.config.output_attentions = True\n",
+    "\n",
+    "for layer_idx in range(num_layers):\n",
+    "    layer = language_model.model.layers[layer_idx]\n",
+    "    attn_module = None\n",
+    "    for attr in ['self_attn', 'attention', 'attn']:\n",
+    "        if hasattr(layer, attr):\n",
+    "            attn_module = getattr(layer, attr)\n",
+    "            break\n",
+    "    if attn_module is not None:\n",
+    "        def create_hook(idx):\n",
+    "            def hook_fn(module, input, output):\n",
+    "                # output may be (hidden_states, attn_probs)\n",
+    "                if isinstance(output, tuple) and len(output) > 1:\n",
+    "                    attn = output[1]\n",
+    "                elif isinstance(output, tuple):\n",
+    "                    attn = output[0]\n",
+    "                else:\n",
+    "                    attn = getattr(module, 'attn_probs', None)\n",
+    "                if attn is not None:\n",
+    "                    attention_data[idx] = attn.detach().cpu()\n",
+    "            return hook_fn\n",
+    "        hooks.append(attn_module.register_forward_hook(create_hook(layer_idx)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    gen_cfg = dict(max_new_tokens=1, do_sample=False)\n",
+    "    if pixel_values is not None and num_patches_list is not None:\n",
+    "        response = model.model.chat(tokenizer, pixel_values, full_prompt, gen_cfg, num_patches_list=num_patches_list)\n",
+    "    elif pixel_values is not None:\n",
+    "        response = model.model.chat(tokenizer, pixel_values, full_prompt, gen_cfg)\n",
+    "    else:\n",
+    "        response = model.model.chat(tokenizer, None, full_prompt, gen_cfg)\n",
+    "print('Model response:', response)\n",
+    "\n",
+    "# restore generate\n",
+    "model.model.generate = orig_generate\n",
+    "\n",
+    "for h in hooks:\n",
+    "    h.remove()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert actual_input_ids is not None, \"failed to capture token ids\"\n",
+    "token_ids = actual_input_ids[0].tolist()\n",
+    "texts = [tokenizer.decode([tid]) for tid in token_ids]\n",
+    "\n",
+    "# group consecutive IMG_CONTEXT tokens\n",
+    "groups = []\n",
+    "labels = []\n",
+    "i = 0\n",
+    "img_count = 0\n",
+    "while i < len(token_ids):\n",
+    "    if token_ids[i] == img_context_token_id:\n",
+    "        j = i\n",
+    "        while j < len(token_ids) and token_ids[j] == img_context_token_id:\n",
+    "            j += 1\n",
+    "        groups.append(list(range(i,j)))\n",
+    "        img_count += 1\n",
+    "        labels.append(f\"IMG{img_count}\")\n",
+    "        i = j\n",
+    "    else:\n",
+    "        groups.append([i])\n",
+    "        labels.append(texts[i])\n",
+    "        i += 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer_to_show = min(24, num_layers-1)\n",
+    "head_to_show = 0\n",
+    "\n",
+    "attn = attention_data[layer_to_show]  # [batch, heads, q_len, k_len]\n",
+    "attn = attn[0, head_to_show].numpy()\n",
+    "\n",
+    "agg = np.zeros((len(groups), len(groups)))\n",
+    "for m, idxs_m in enumerate(groups):\n",
+    "    for n, idxs_n in enumerate(groups):\n",
+    "        agg[m,n] = attn[np.ix_(idxs_m, idxs_n)].mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,8))\n",
+    "sns.heatmap(agg, xticklabels=labels, yticklabels=labels, cmap='viridis', vmin=0, vmax=agg.max())\n",
+    "plt.title(f'Layer {layer_to_show} Head {head_to_show} Attention')\n",
+    "plt.xlabel('Key positions')\n",
+    "plt.ylabel('Query positions')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new notebook demonstrating how to capture and visualise attention heads
- load model and VL-ICL benchmark
- hook attention modules during a forward pass to record head scores
- aggregate image tokens for clearer heatmaps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a5779601083238f4a203e13d1cfb9